### PR TITLE
Addded metrics for getchaintips

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -27,6 +27,12 @@ var (
 		[]string{
 			"type",
 		})
+	zcashdChainTips = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "zcash_chain_tip",
+			Help: "Return information about all known tips in the block tree, including the main chain as well as orphaned branches."},
+		[]string{"height", "hash", "branchlen", "status"},
+	)
 )
 
 // ZCASH_PEERS = Gauge("zcash_peers", "Number of peers")
@@ -61,4 +67,5 @@ func init() {
 	prometheus.MustRegister(zcashdMemPoolBytes)
 	prometheus.MustRegister(zcashdMemPoolUsage)
 	prometheus.MustRegister(zcashdWalletBalance)
+	prometheus.MustRegister(zcashdChainTips)
 }

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	go getBlockchainInfo()
 	go getMemPoolInfo()
 	go getWalletInfo()
+	go getChainTips()
 	log.Infoln("Listening on", *listenAddress)
 	if err := http.ListenAndServe(*listenAddress, nil); err != nil {
 		log.Fatal(err)
@@ -127,6 +128,33 @@ func getWalletInfo() {
 			}
 			if total, err := strconv.ParseFloat(walletinfo.Total, 64); err == nil {
 				zcashdWalletBalance.WithLabelValues("total").Set(total)
+			}
+		}
+		time.Sleep(time.Duration(30) * time.Second)
+	}
+
+}
+
+func getChainTips() {
+	basicAuth := base64.StdEncoding.EncodeToString([]byte(*rpcUser + ":" + *rpcPassword))
+	rpcClient := jsonrpc.NewClientWithOpts("http://"+*rpcHost+":"+*rpcPort,
+		&jsonrpc.RPCClientOpts{
+			CustomHeaders: map[string]string{
+				"Authorization": "Basic " + basicAuth,
+			}})
+	var chaintips *GetChainTips
+
+	for {
+		if err := rpcClient.CallFor(&chaintips, "getchaintips"); err != nil {
+			log.Warnln("Error calling getchaintips", err)
+		} else {
+			for _, ct := range *chaintips {
+				log.Infoln("Got chaintip: ", ct.Height)
+				zcashdChainTips.WithLabelValues(
+					strconv.FormatFloat(ct.Height, 'f', 2, 64),
+					ct.Hash,
+					strconv.FormatFloat(ct.Branchlen, 'f', 2, 64),
+					ct.Status).Set(ct.Height)
 			}
 		}
 		time.Sleep(time.Duration(30) * time.Second)

--- a/rpc.go
+++ b/rpc.go
@@ -25,3 +25,14 @@ type ZGetTotalBalance struct {
 	Private     string `json:"private"`
 	Total       string `json:"total"`
 }
+
+// GetChainTips Return information about all known tips in the block tree, including the main chain as well as orphaned branches.
+// https://zcash-rpc.github.io/getchaintips.html
+type GetChainTips []ChainTip
+
+type ChainTip struct {
+	Height    float64 `json:"height"`
+	Hash      string  `json:"hash"`
+	Branchlen float64 `json:"branchlen"`
+	Status    string  `json:"status"`
+}


### PR DESCRIPTION
- added new metric for capturing chaintip length per hash.


The metrics will looks something like this:
```
$ curl -s localhost:9100/metrics| grep chain
# HELP zcash_chain_tip Return information about all known tips in the block tree, including the main chain as well as orphaned branches.
# TYPE zcash_chain_tip gauge
zcash_chain_tip{branchlen="0.00",hash="000000000006c3e942e02a524ecfa8b291f724a4ad55311da1d815a7d969e024",height="644234.00",status="active"} 644234
zcash_chain_tip{branchlen="0.00",hash="000000000007318e4b24a545d1000512726eff71b9493f402746ea17b4c4c4df",height="644247.00",status="active"} 644247
zcash_chain_tip{branchlen="0.00",hash="00000000000c6fb40790918f8da6c2ab648f33c4b7991d473b6ea79aa512df92",height="644232.00",status="active"} 644232
zcash_chain_tip{branchlen="0.00",hash="000000000010e7fa4600ea9b2da4c4052ff2318772ea549fa805b703d858d620",height="644248.00",status="active"} 644248
zcash_chain_tip{branchlen="0.00",hash="000000000022e92798ffb0b244b5f05a98e0e10040f6a2a177473dbabe294c2a",height="644233.00",status="active"} 644233
zcash_chain_tip{branchlen="0.00",hash="00000000003619ed4306d7cac61f1b8030bc72e74395783f9cc9129aac26a4d0",height="644236.00",status="active"} 644236
zcash_chain_tip{branchlen="0.00",hash="000000000045c00c3e32954d4b63c4b448c6418970b393dde108ca024ec7c55e",height="644230.00",status="active"} 644230
zcash_chain_tip{branchlen="0.00",hash="0000000000480afe1669c42aa3e32f011ee1af1b79e75f987ab57db667447fd9",height="644241.00",status="active"} 644241
zcash_chain_tip{branchlen="0.00",hash="00000000006d7b7ca6852e3016349777eeed65007f64dbeaa90b2a5b4dfd8340",height="644245.00",status="active"} 644245
zcash_chain_tip{branchlen="0.00",hash="000000000083724adbca3ac95e2d155ced757256fb46c24bf505ef1438735f49",height="644231.00",status="active"} 644231
zcash_chain_tip{branchlen="0.00",hash="0000000000bcde6015f75ad8c43e83873785adcf8d2673ed430849ce879cff81",height="644239.00",status="active"} 644239
```
