### PR TITLE
Use zcash_chainip_length instead of zcash_chainips_at_height

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -52,12 +52,12 @@ var (
 			Help: "Bytes received from peer node."},
 		[]string{"addr", "addrlocal", "inbound", "banscore", "subver"},
 	)
-	zcashdChainTips = prometheus.NewGaugeVec(
+	zcashdChainTipLength = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "zcash_chainips_at_height",
-			Help: "Information about all known tips in the block tree.",
+			Name: "zcash_chainip_length",
+			Help: "Chain tip length",
 		},
-		[]string{"hash", "branchlen", "status"},
+		[]string{"hash", "status", "height"},
 	)
 )
 
@@ -97,5 +97,5 @@ func init() {
 	prometheus.MustRegister(zcashdPeerConnTime)
 	prometheus.MustRegister(zcashdPeerBytesSent)
 	prometheus.MustRegister(zcashdPeerBytesRecv)
-	prometheus.MustRegister(zcashdChainTips)
+	prometheus.MustRegister(zcashdChainTipLength)
 }

--- a/main.go
+++ b/main.go
@@ -223,11 +223,11 @@ func getChainTips() {
 		} else {
 			for _, ct := range *chaintips {
 				log.Infoln("Got chaintip: ", ct.Hash)
-				zcashdChainTips.WithLabelValues(
+				zcashdChainTipLength.WithLabelValues(
 					ct.Hash,
-					strconv.Itoa(ct.Branchlen),
 					ct.Status,
-				).Set(float64(ct.Height))
+					strconv.Itoa(ct.Height),
+				).Set(float64(ct.Branchlen))
 			}
 		}
 		time.Sleep(time.Duration(30) * time.Second)


### PR DESCRIPTION
Refactoring the chain tips metric.

The chain tip length is now the metric value. It has labels of
- hash
- status
- height

This change allows better monitoring of chain tips by length, which seem to be the most important metric.
